### PR TITLE
Add Tag support in OpenAPI parser for method object

### DIFF
--- a/src/Parser/OpenAPI.php
+++ b/src/Parser/OpenAPI.php
@@ -149,6 +149,10 @@ class OpenAPI implements ParserInterface, ParserCollectionInterface
                     $method->setDescription($operation['summary']);
                 }
 
+                if (isset($operation['tags'])) {
+                    $method->setTags($operation['tags']);
+                }
+
                 $this->parseQueryParameters($method, $operation);
                 $this->parseRequest($method, $operation);
                 $this->parseResponses($method, $operation);

--- a/tests/Resource/MethodAbstractTest.php
+++ b/tests/Resource/MethodAbstractTest.php
@@ -40,6 +40,7 @@ class MethodAbstractTest extends \PHPUnit_Framework_TestCase
         $method->addQueryParameter('foo', Property::getString());
         $method->setRequest(new Schema(Property::getString()));
         $method->addResponse(200, new Schema(Property::getString()));
+        $method->setTags(['Foo']);
 
         $this->assertEquals('foobar', $method->getDescription());
         $this->assertInstanceOf('PSX\Schema\PropertyInterface', $method->getQueryParameters());
@@ -49,6 +50,8 @@ class MethodAbstractTest extends \PHPUnit_Framework_TestCase
         $this->assertTrue($method->hasResponse(200));
         $this->assertFalse($method->hasResponse(201));
         $this->assertTrue($method->hasQueryParameters());
+        $this->assertInternalType('array', $method->getTags());
+        $this->assertEquals('Foo', current($method->getTags()));
     }
 
     /**

--- a/tests/Resource/petstore/openapi.json
+++ b/tests/Resource/petstore/openapi.json
@@ -46,7 +46,10 @@
               }
             }
           }
-        }
+        },
+        "tags": [
+          "pets"
+        ]
       },
       "post": {
         "description": "Create a pet",
@@ -71,7 +74,10 @@
               }
             }
           }
-        }
+        },
+        "tags": [
+          "pets"
+        ]
       },
       "parameters": []
     }

--- a/tests/Resource/petstore/swagger.json
+++ b/tests/Resource/petstore/swagger.json
@@ -36,7 +36,10 @@
               "$ref": "#\/definitions\/Error"
             }
           }
-        }
+        },
+        "tags": [
+          "pets"
+        ]
       },
       "post": {
         "description": "Create a pet",
@@ -59,7 +62,10 @@
               "$ref": "#\/definitions\/Error"
             }
           }
-        }
+        },
+        "tags": [
+          "pets"
+        ]
       },
       "parameters": []
     }


### PR DESCRIPTION
This PR sets the tags on a method object inside the `parseResource` function of the OpenAPI parser.

`\PSX\Api\Resource\MethodAbstract` supports tags already so it is just a matter of setting them ;-)